### PR TITLE
Fix: Add Netlify configuration to resolve failing checks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,18 @@
+# This file configures the build settings for Netlify.
+# It tells Netlify to only build the frontend application located in the "client" directory.
+
+[build]
+  # Set the base directory to "client". All commands will be run from here.
+  base = "client/"
+
+  # The command to build the frontend site.
+  # This will run `npm run build` inside the `client` directory.
+  command = "npm run build"
+
+  # The directory that contains the built frontend assets, relative to the base directory.
+  publish = "dist/"
+
+[dev]
+  # Hint for Netlify's dev environment that this is a Vite project.
+  framework = "#vite"
+  port = 5173


### PR DESCRIPTION
This commit introduces a `netlify.toml` file to correctly configure the build process on Netlify.

The previous `deploy-preview` was failing because Netlify was attempting to build the entire full-stack application from the root, which is incompatible with its frontend-oriented build environment.

The new `netlify.toml` file scopes the build to the `client/` directory, ensuring only frontend dependencies are installed and the correct build command is run. This is expected to fix the entire cascade of failing Netlify checks.